### PR TITLE
foutje in DbContext

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ In `Startup.cs` add the following line in the `ConfigureServices()`</br>
       // Constructor
       public Context(DbContextOptions<Context> FileOptions, IOptions<ConnectionStrings> connectionStrings) {
 
-        _connectionStrings = connectionStrings;
+        _connectionStrings = connectionStrings.Value;
 
       }
 


### PR DESCRIPTION
connectionStrings is van type IOptions<ConnectionStrings>, dus als je de connectionstring wil opslaan in een variabele met type ConnectionStrings, moet je eerst de Value uit het IOptions object halen.